### PR TITLE
Trinity christiana patch 1

### DIFF
--- a/deshawnapi/models/dog.py
+++ b/deshawnapi/models/dog.py
@@ -1,7 +1,7 @@
 from django.db import models
-
+from .walker import Walker
 
 class Dog(models.Model):
     name = models.CharField(max_length=155)
-    walker = models.ForeignKey('Walker', on_delete=models.CASCADE, related_name='dogs')
+    walker = models.ForeignKey(Walker, on_delete=models.CASCADE, related_name='dogs')
 

--- a/deshawnapi/models/walker.py
+++ b/deshawnapi/models/walker.py
@@ -1,8 +1,8 @@
 from django.db import models
-
+from .city import City
 
 class Walker(models.Model):
     name = models.CharField(max_length=155)
     email = models.CharField(max_length=155)
-    city = models.ForeignKey('City', on_delete=models.CASCADE, related_name='walkers')
+    city = models.ForeignKey(City, on_delete=models.CASCADE, related_name='walkers')
 


### PR DESCRIPTION
Deleting the models' string references for the Foreign Key fields.

In order to give students direct feedback when they assign a model to a foreign key when the model does not exist, we would like to remove these.